### PR TITLE
OpenMVG importer enhancement

### DIFF
--- a/main_openmvg.cpp
+++ b/main_openmvg.cpp
@@ -215,11 +215,13 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    std::string cam_model;
     for(rapidjson::SizeType i=0; i<intr.Size(); ++i)
     {
         rapidjson::Value& array_element = intr[i];
         rapidjson::Value& intr_data = array_element["value"]["ptr_wrapper"]["data"];
-        std::string cam_model = array_element["value"]["polymorphic_name"].GetString();
+        if (array_element["value"].HasMember("polymorphic_name"))
+          cam_model = array_element["value"]["polymorphic_name"].GetString();
         unsigned int groupID = array_element["key"].GetUint();
 
         bool distorted = false;


### PR DESCRIPTION
Add ability to handle an OpenMVG sfm_data.json file that contains many intrinsics group.

Since Cereal JSON serialization log the polymorphic_name once per TYPE, we need to check if the polymorphic_name is present or not (if not we use the previous defined one). =>
https://github.com/USCiLab/cereal/blob/2f9471bc401590cf58b38bbbc33d412dade6d589/include/cereal/details/polymorphic_impl.hpp#L205

For example in the following example, you see two defined intrinsic and in the second the polymorphic_name is not duplicated, since it was defined before (in the Key 0).

```
"intrinsics": [
        {
            "key": 0,
            "value": {
                "polymorphic_id": 2147483649,
                "polymorphic_name": "pinhole_radial_k3",
                "ptr_wrapper": {
                    "id": 2147483657,
                    "data": {
                        "width": 5472,
                        "height": 3648,
                        "focal_length": 10967.472502860763,
                        "principal_point": [
                            2706.8848433426251,
                            1811.8657125585839
                        ],
                        "disto_k3": [
                            -0.0026826376258702002,
                            0.208797991285879,
                            -0.42001821068673345
                        ]
                    }
                }
            }
        },
        {
            "key": 1,
            "value": {
                "polymorphic_id": 1,
                "ptr_wrapper": {
                    "id": 2147483658,
                    "data": {
                        "width": 5472,
                        "height": 3648,
                        "focal_length": 11218.29225700226,
                        "principal_point": [
                            2707.4651729840366,
                            1825.3803007893732
                        ],
                        "disto_k3": [
                            0.012729924046947002,
                            0.089827993696145081,
                            0.53176328513547466
                        ]
                    }
                }
            }
        }
```
