### PR TITLE
Windows modifications

### DIFF
--- a/commons.h
+++ b/commons.h
@@ -29,6 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <queue>
 #include <stdlib.h>
 
+// windows fix
+#define M_PI   3.14159265358979323846264338327950288
+#define M_PI_2 1.57079632679489661923132169163975144
+
+
 /**
  * Line3D++ - Constants
  * ====================

--- a/line3D.cc
+++ b/line3D.cc
@@ -1,5 +1,8 @@
 #include "line3D.h"
 
+// windows fix
+#define size_t int
+
 namespace L3DPP
 {
     //------------------------------------------------------------------------------

--- a/main_bundler.cpp
+++ b/main_bundler.cpp
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(unsigned int i=0; i<num_cams; ++i)
+    for(int i=0; i<num_cams; ++i)
     {   
         // load image
         std::string img_filename = "";

--- a/main_colmap.cpp
+++ b/main_colmap.cpp
@@ -362,7 +362,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(unsigned int i=0; i<img_seq.size(); ++i)
+    for(int i=0; i<img_seq.size(); ++i)
     {
         // get camera params
         unsigned int imgID = img_seq[i];

--- a/main_mavmap.cpp
+++ b/main_mavmap.cpp
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(unsigned int i=0; i<cams_rotation.size(); ++i)
+    for(int i=0; i<cams_rotation.size(); ++i)
     {
         // load image
         std::string img_filename = imgPrefix+cams_filenames[i];

--- a/main_openmvg.cpp
+++ b/main_openmvg.cpp
@@ -375,7 +375,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(unsigned int i=0; i<num_cams; ++i)
+    for(int i=0; i<num_cams; ++i)
     {
         unsigned int camID = cams_view_IDs[i];
         unsigned int intID = cams_intrinsic_IDs[i];

--- a/main_pix4d.cpp
+++ b/main_pix4d.cpp
@@ -365,7 +365,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(size_t i=0; i<feat_observations.size(); ++i)
+    for(int i=0; i<feat_observations.size(); ++i)
     {
         std::list<std::pair<size_t,Eigen::Vector2d> > obs = feat_observations[i];
         if(obs.size() > 2)
@@ -384,7 +384,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(unsigned int i=0; i<cams_rotation.size(); ++i)
+    for(int i=0; i<cams_rotation.size(); ++i)
     {
         // load image
         std::string img_filename = imageFolder+"/"+cams_filenames[i];

--- a/main_vsfm.cpp
+++ b/main_vsfm.cpp
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 #ifdef L3DPP_OPENMP
     #pragma omp parallel for
 #endif //L3DPP_OPENMP
-    for(unsigned int i=0; i<num_cams; ++i)
+    for(int i=0; i<num_cams; ++i)
     {
         if(cams_worldpointDepths[i].size() > 0)
         {

--- a/optimization.cc
+++ b/optimization.cc
@@ -1,5 +1,8 @@
 #include "optimization.h"
 
+// windows fix
+#define size_t int
+
 #ifdef L3DPP_CERES
 
 namespace L3DPP

--- a/view.cc
+++ b/view.cc
@@ -1,5 +1,8 @@
 #include "view.h"
 
+// windows fix
+#define size_t int
+
 namespace L3DPP
 {
     //------------------------------------------------------------------------------


### PR DESCRIPTION
Very minor changes allow this to be compiled on Windows with "Visual Studio 15 2017 Win64".

I use the following package/versions using vcpkg:
opencv:x64-windows 3.4.0-2
ceres:x64-windows 1.13.0-4
boost:x64-windows 1.66.0
eigen3:x64-windows 3.3.4-2
tclap:x64-windows 1.2.2

There are 2 small changes:

1. Simply defining M_PI and M_PI_2. The standard Windows way to do this is to `#define _USE_MATH_DEFINES` before including cmath or math.h. In this, I just explicitly define PI and PI / 2.
2. Replacing `unsigned int` and `size_t` with `int` in the OpenMP loops. The way I did this is quite hacky, so feel free to ditch this, and do a better job yourself (if you prefer).

Thanks!