### PR TITLE
Less hacky modification for Windows

### DIFF
--- a/commons.h
+++ b/commons.h
@@ -30,8 +30,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdlib.h>
 
 // windows fix
+#if _WIN32
 #define M_PI   3.14159265358979323846264338327950288
 #define M_PI_2 1.57079632679489661923132169163975144
+#endif
 
 
 /**

--- a/line3D.cc
+++ b/line3D.cc
@@ -1,8 +1,5 @@
 #include "line3D.h"
 
-// windows fix
-#define size_t int
-
 namespace L3DPP
 {
     //------------------------------------------------------------------------------
@@ -441,7 +438,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<view_order_.size(); ++i)
+        for(int i=0; i<view_order_.size(); ++i)
         {
             unsigned int camID = view_order_[i];
 
@@ -463,7 +460,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<view_order_.size(); ++i)
+        for(int i=0; i<view_order_.size(); ++i)
         {
             unsigned int camID = view_order_[i];
 
@@ -512,7 +509,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<3; ++i)
+        for(int i=0; i<3; ++i)
         {
             std::map<unsigned int,L3DPP::View*>::const_iterator it = views_.begin();
             for(; it!=views_.end(); ++it)
@@ -554,7 +551,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<view_order_.size(); ++i)
+        for(int i=0; i<view_order_.size(); ++i)
         {
             views_[view_order_[i]]->translate(t);
         }
@@ -563,7 +560,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<lines3D_.size(); ++i)
+        for(int i=0; i<lines3D_.size(); ++i)
         {
             L3DPP::FinalLine3D L = lines3D_[i];
             std::list<L3DPP::Segment3D>::iterator it = L.collinear3Dsegments_.begin();
@@ -821,7 +818,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<matches_[src].size(); ++i)
+        for(int i=0; i<matches_[src].size(); ++i)
         {
             std::list<L3DPP::Match> remaining;
 
@@ -914,7 +911,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t r=0; r<lines_src->width(); ++r)
+        for(int r=0; r<lines_src->width(); ++r)
         {
             int new_matches = 0;
 
@@ -1201,7 +1198,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<matches_[src].size(); ++i)
+        for(int i=0; i<matches_[src].size(); ++i)
         {
             matches_[src][i].sort(L3DPP::sortMatchesByIDs);
         }
@@ -1221,7 +1218,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<matches_[src].size(); ++i)
+        for(int i=0; i<matches_[src].size(); ++i)
         {
             bool valid_match_exists = false;
 
@@ -1338,7 +1335,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<matches_[src].size(); ++i)
+        for(int i=0; i<matches_[src].size(); ++i)
         {
             int offset = ranges->dataCPU(i,0)[0].x;
             if(offset >= 0)
@@ -1374,7 +1371,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<matches_[src].size(); ++i)
+        for(int i=0; i<matches_[src].size(); ++i)
         {
             bool valid_match_exists = false;
             int offset = ranges->dataCPU(i,0)[0].x;
@@ -1611,7 +1608,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<matches_[src].size(); ++i)
+        for(int i=0; i<matches_[src].size(); ++i)
         {
             L3DPP::Match best_match;
             best_match.score3D_ = 0.0f;
@@ -1864,7 +1861,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<estimated_position3D_.size(); ++i)
+        for(int i=0; i<estimated_position3D_.size(); ++i)
         {
             L3DPP::Segment3D seg3D = estimated_position3D_[i].first;
             L3DPP::Match m = estimated_position3D_[i].second;
@@ -2128,7 +2125,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<unique_clusters.size(); ++i)
+        for(int i=0; i<unique_clusters.size(); ++i)
         {
             int clID = unique_clusters[i];
 
@@ -2284,7 +2281,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<clusters3D_.size(); ++i)
+        for(int i=0; i<clusters3D_.size(); ++i)
         {
             std::list<L3DPP::Segment3D> collinear = findCollinearSegments(clusters3D_[i]);
 
@@ -2312,7 +2309,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<lines3D_.size(); ++i)
+        for(int i=0; i<lines3D_.size(); ++i)
         {
             L3DPP::View* v = views_[lines3D_[i].underlyingCluster_.reference_view()];
 

--- a/optimization.cc
+++ b/optimization.cc
@@ -1,8 +1,5 @@
 #include "optimization.h"
 
-// windows fix
-#define size_t int
-
 #ifdef L3DPP_CERES
 
 namespace L3DPP
@@ -31,7 +28,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<clusters3D_->size(); ++i)
+        for(int i=0; i<clusters3D_->size(); ++i)
         {
             L3DPP::LineCluster3D LC = clusters3D_->at(i);
 

--- a/view.cc
+++ b/view.cc
@@ -1,8 +1,5 @@
 #include "view.h"
 
-// windows fix
-#define size_t int
-
 namespace L3DPP
 {
     //------------------------------------------------------------------------------
@@ -195,7 +192,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t i=0; i<collin_.size(); ++i)
+        for(int i=0; i<collin_.size(); ++i)
         {
             for(size_t c=0; c<buffer->width(); ++c)
             {
@@ -220,7 +217,7 @@ namespace L3DPP
 #ifdef L3DPP_OPENMP
         #pragma omp parallel for
 #endif //L3DPP_OPENMP
-        for(size_t r=0; r<collin_.size(); ++r)
+        for(int r=0; r<collin_.size(); ++r)
         {
             Eigen::Vector3d p[2];
             float4 l1 = lines_->dataCPU(r,0)[0];


### PR DESCRIPTION
Added `#if _WIN32` so that it doesn't produce redefinition warnings for M_PI on Ubuntu, and only defines M_PI on Windows.

The first pull request felt a bit dirty - I changed my mind on the `#define size_t int` thing. Instead changed the problematic `size_t`'s to `int`'s explicitly.

Now this compiles with fewer warnings on Windows, and no warnings on Ubuntu.